### PR TITLE
Fix build error of CI-Build refered to pullrequest #149

### DIFF
--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -4,9 +4,7 @@ HOMEPAGE = "http://mono-project.com"
 BUGTRACKER = "http://bugzilla.xamarin.com/"
 SECTION = "devel"
 
-# This include is used in both mono and mono-native variants
-DEPENDS:class-target += "zlib libatomic-ops cmake-native"
-DEPENDS:class-native += "zlib-native libatomic-ops-native cmake-native"
+DEPENDS += "zlib libatomic-ops"
 
 SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.xz \
            file://dllmap-config.in.diff \


### PR DESCRIPTION
See error of [CI-Build](https://github.com/DynamicDevices/meta-mono/actions/runs/3419545584/jobs/5693201978) of [Pullrequest](https://github.com/DynamicDevices/meta-mono/pull/149)  #149 :

 Problem 1: conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64

 Problem 2: package msbuild-16.6-r0.core2_64 requires mono, but none of the providers can be installed
  - conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64

 Problem 3: package mono-helloworld-1.2-r0.core2_64 requires mono, but none of the providers can be installed
  - conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64 (try to add '--skip-broken' to skip uninstallable packages)